### PR TITLE
Add 'meeting' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ For example, you can add it to crontab if some people forget to punch out at the
 * `morning` - same as `hi`
 * `office` - same as `hi In the office`
 * `home` - same as `hi WFH`
+* `meeting` - same as `hi In a meeting`
 
 *Punching out:*
 

--- a/src/bot.rb
+++ b/src/bot.rb
@@ -38,6 +38,15 @@ class PunchCardBot < SlackRubyBot::Bot
     )
   end
 
+  match /^meeting/i do |client, data, _match|
+    InCommand.new('In a meeting').execute(client, data)
+    client.web_client.reactions_add(
+      channel: data.channel,
+      timestamp: data.ts,
+      name: 'briefcase'
+    )
+  end
+
   match /^home/i do |client, data, _match|
     InCommand.new('WFH').execute(client, data)
     client.web_client.reactions_add(

--- a/src/commands/help_command.rb
+++ b/src/commands/help_command.rb
@@ -16,6 +16,7 @@ class HelpCommand
       \t`morning` - same as `hi`
       \t`office` - same as `hi In the office`
       \t`home` - same as `hi WFH`
+      \t`meeting` - same as `hi In a meeting`
       *Punching out:*
       \t`out`, `out <optional text>` - punches you out
       \t`off`, `off <optional text>` - same as `out`


### PR DESCRIPTION
Why:

Some people wanted to indicate that they are working, but are in the
meeting.

This change addresses the need by:

This adds a new command `meeting` that does the same thing as `hi` with
some additional description.